### PR TITLE
Switch to different maven repository for launcher-fancy dependency

### DIFF
--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -7,14 +7,14 @@ mainClassName = "com.skcraft.launcher.FancyLauncher"
 
 repositories {
     maven {
-        name = 'cottonmc-maven'
-        url = 'https://server.bbkr.space/artifactory/libs-snapshot/'
+        name = 'obw maven'
+        url = 'https://maven.offbeatwit.ch/repository/snapshots'
     }
 }
 
 dependencies {
     compile project(':launcher')
-    compile 'io.github.cottonmc.insubstantial:substance:7.3.1-20190628.121938-1'
+    compile 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT'
 }
 
 shadowJar {


### PR DESCRIPTION
seems like server.bbkr.space went down, so I republished